### PR TITLE
Music Fix in Main Zoom Scene

### DIFF
--- a/obs/openshift_streaming/basic/scenes/Ask_an_OpenShift_Admin.json
+++ b/obs/openshift_streaming/basic/scenes/Ask_an_OpenShift_Admin.json
@@ -1604,7 +1604,7 @@
                         "crop_top": 0,
                         "group_item_backup": false,
                         "id": 26,
-                        "locked": false,
+                        "locked": true,
                         "name": "Elevator Music",
                         "pos": {
                             "x": 0.0,

--- a/obs/openshift_streaming/basic/scenes/Ask_an_OpenShift_Admin.json
+++ b/obs/openshift_streaming/basic/scenes/Ask_an_OpenShift_Admin.json
@@ -175,7 +175,7 @@
             },
             "sync": 0,
             "versioned_id": "ffmpeg_source",
-            "volume": 0.0097726993262767792
+            "volume": 0.40000000596046448
         },
         {
             "balance": 0.5,

--- a/obs/openshift_streaming/basic/scenes/GitOps_Guide_to_the_Galaxy.json
+++ b/obs/openshift_streaming/basic/scenes/GitOps_Guide_to_the_Galaxy.json
@@ -858,7 +858,7 @@
                         "crop_top": 0,
                         "group_item_backup": false,
                         "id": 25,
-                        "locked": false,
+                        "locked": true,
                         "name": "Elevator Music",
                         "pos": {
                             "x": 0.0,

--- a/obs/openshift_streaming/basic/scenes/GitOps_Guide_to_the_Galaxy.json
+++ b/obs/openshift_streaming/basic/scenes/GitOps_Guide_to_the_Galaxy.json
@@ -175,7 +175,7 @@
             },
             "sync": 0,
             "versioned_id": "ffmpeg_source",
-            "volume": 0.0081975283101201057
+            "volume": 0.40000000596046448
         },
         {
             "balance": 0.5,

--- a/obs/openshift_streaming/basic/scenes/In_The_Clouds.json
+++ b/obs/openshift_streaming/basic/scenes/In_The_Clouds.json
@@ -175,7 +175,7 @@
             },
             "sync": 0,
             "versioned_id": "ffmpeg_source",
-            "volume": 0.0046494039706885815
+            "volume": 0.40000000596046448
         },
         {
             "balance": 0.5,

--- a/obs/openshift_streaming/basic/scenes/In_The_Clouds.json
+++ b/obs/openshift_streaming/basic/scenes/In_The_Clouds.json
@@ -1233,7 +1233,7 @@
                         "crop_top": 0,
                         "group_item_backup": false,
                         "id": 25,
-                        "locked": false,
+                        "locked": true,
                         "name": "Elevator Music",
                         "pos": {
                             "x": 0.0,

--- a/obs/openshift_streaming/basic/scenes/OpenShift_Commons.json
+++ b/obs/openshift_streaming/basic/scenes/OpenShift_Commons.json
@@ -144,7 +144,7 @@
             },
             "sync": 0,
             "versioned_id": "ffmpeg_source",
-            "volume": 0.0030941269360482693
+            "volume": 0.40000000596046448
         },
         {
             "balance": 0.5,

--- a/obs/openshift_streaming/basic/scenes/OpenShift_Commons.json
+++ b/obs/openshift_streaming/basic/scenes/OpenShift_Commons.json
@@ -396,7 +396,7 @@
                         "crop_top": 0,
                         "group_item_backup": false,
                         "id": 12,
-                        "locked": false,
+                        "locked": true,
                         "name": "Elevator Music",
                         "pos": {
                             "x": 0.0,

--- a/obs/openshift_streaming/basic/scenes/OpenShift_Streaming.json
+++ b/obs/openshift_streaming/basic/scenes/OpenShift_Streaming.json
@@ -178,7 +178,7 @@
             },
             "sync": 0,
             "versioned_id": "ffmpeg_source",
-            "volume": 0.0048883091658353806
+            "volume": 0.40000000596046448
         },
         {
             "balance": 0.5,

--- a/obs/openshift_streaming/basic/scenes/OpenShift_Streaming.json
+++ b/obs/openshift_streaming/basic/scenes/OpenShift_Streaming.json
@@ -812,7 +812,7 @@
                         "crop_top": 0,
                         "group_item_backup": false,
                         "id": 22,
-                        "locked": false,
+                        "locked": true,
                         "name": "Elevator Music",
                         "pos": {
                             "x": 0.0,

--- a/obs/openshift_streaming/basic/scenes/OpenShift_What's_New.json
+++ b/obs/openshift_streaming/basic/scenes/OpenShift_What's_New.json
@@ -175,7 +175,7 @@
             },
             "sync": 0,
             "versioned_id": "ffmpeg_source",
-            "volume": 0.0022341827861964703
+            "volume": 0.40000000596046448
         },
         {
             "balance": 0.5,

--- a/obs/openshift_streaming/basic/scenes/OpenShift_What's_New.json
+++ b/obs/openshift_streaming/basic/scenes/OpenShift_What's_New.json
@@ -170,7 +170,7 @@
             "push-to-talk": false,
             "push-to-talk-delay": 0,
             "settings": {
-                "local_file": "C:/streaming-tools/obs/assets/elevator music.mp3",
+                "local_file": "C:/streaming-tools/obs/assets/elevator-music.mp3",
                 "looping": true
             },
             "sync": 0,
@@ -1061,7 +1061,7 @@
                         "crop_top": 0,
                         "group_item_backup": false,
                         "id": 26,
-                        "locked": false,
+                        "locked": true,
                         "name": "Elevator Music",
                         "pos": {
                             "x": 0.0,

--- a/obs/openshift_streaming/basic/scenes/The_Level_Up_Hour.json
+++ b/obs/openshift_streaming/basic/scenes/The_Level_Up_Hour.json
@@ -1917,7 +1917,7 @@
             },
             "sync": 0,
             "versioned_id": "ffmpeg_source",
-            "volume": 0.0024871004279702902
+            "volume": 0.40000000596046448
         }
     ],
     "transition_duration": 300,

--- a/obs/openshift_streaming/basic/scenes/The_Level_Up_Hour.json
+++ b/obs/openshift_streaming/basic/scenes/The_Level_Up_Hour.json
@@ -879,7 +879,7 @@
                         "crop_top": 0,
                         "group_item_backup": false,
                         "id": 26,
-                        "locked": false,
+                        "locked": true,
                         "name": "Elevator Music",
                         "pos": {
                             "x": 0.0,


### PR DESCRIPTION
Music was automatically playing on the Main Zoom Scene, so I went through and made sure Visible was set to false for all of them and also locked their positions. 
There was also a typo in the What's New section that prevented the music from being played, so that has been fixed as well. 